### PR TITLE
update clang versions in CI workflows

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,performance-*,bugprone-*,clang-analyzer-*,mpi-*,misc-*,readability-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     'file'
 CheckOptions:
   - key:             bugprone-argument-comment.CommentBoolLiterals

--- a/.github/workflows/cpp-lint-action.yml
+++ b/.github/workflows/cpp-lint-action.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        clang-version: ['9','10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20']
+        clang-version: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22']
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp-lint-package.yml
+++ b/.github/workflows/cpp-lint-package.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        clang-version: ['9','10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20']
+        clang-version: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22']
         repo: ['cpp-linter/cpp-linter']
         branch: ['${{ inputs.branch }}']
       fail-fast: false


### PR DESCRIPTION
This also removes a clang-tidy check that was deprecated in v16 and removed in v18. It now triggers a clang-tidy error since v18