### PR TITLE
test: auto-fix end-to-end (do not merge)

### DIFF
--- a/.github/workflows/test-auto-fix.yml
+++ b/.github/workflows/test-auto-fix.yml
@@ -1,0 +1,31 @@
+name: e2e auto-fix test
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  auto-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: cpp-linter/cpp-linter-action@test/auto-fix-e2e
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          tidy-checks: '-*'  # disable clang-tidy; test clang-format auto-fix only
+          files-changed-only: false
+          version: '18'
+          auto-fix: true
+          verbosity: debug
+
+      - name: Report
+        run: |
+          echo "clang-format-checks-failed: ${{ steps.linter.outputs.clang-format-checks-failed }}"

--- a/src/auto_fix_demo.cpp
+++ b/src/auto_fix_demo.cpp
@@ -1,2 +1,10 @@
 #include <cstdio>
-int   main( ){int x=0 ;for(int i=0;i<10;i++){x +=i;}printf("%d",x);return 0 ;}
+int main()
+{
+    int x = 0;
+    for (int i = 0; i < 10; i++) {
+        x += i;
+    }
+    printf("%d", x);
+    return 0;
+}

--- a/src/auto_fix_demo.cpp
+++ b/src/auto_fix_demo.cpp
@@ -1,0 +1,2 @@
+#include <cstdio>
+int   main( ){int x=0 ;for(int i=0;i<10;i++){x +=i;}printf("%d",x);return 0 ;}

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -1,7 +1,7 @@
 /** This is a very ugly test code (doomed to fail linting) */
 #include "demo.hpp"
-#include <cstdio>
 #include <cstddef>
+#include <cstdio>
 
 // using size_t from cstddef
 size_t dummyFunc(size_t i) { return i; }

--- a/src/demo.hpp
+++ b/src/demo.hpp
@@ -1,41 +1,17 @@
 #pragma once
 
-
-
 class Dummy {
     char* useless;
     int numb;
 
-    public:
-    void *not_usefull(char *str){
+public:
+    void* not_usefull(char* str)
+    {
         useless = str;
         return 0;
     }
 };
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-struct LongDiff
-{
+struct LongDiff {
     long diff;
-
 };


### PR DESCRIPTION
Throwaway PR to end-to-end test the `auto-fix` feature.

- Uses `cpp-linter/cpp-linter-action@test/auto-fix-e2e` (which installs the unreleased `cpp-linter` `--fix` from the `feature/auto-fix` branch).
- Contains a deliberately mis-formatted `src/auto_fix_demo.cpp`.
- Expectation: the action runs `cpp-linter --fix`, reformats the file, and pushes an auto-fix commit back to this PR branch.

Do not merge — this is a temporary test.

---
_Generated by [Claude Code](https://claude.ai/code/session_012uXrN1wk5EaqK5GimN3deT)_